### PR TITLE
Support for native simulator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ __pycache__
 /.vscode/
 /doc/_build_doxygen
 /doc/_build_sphinx
+
+# files from native_sim flash simulation
+/flash
+/flash.bin

--- a/README.md
+++ b/README.md
@@ -113,19 +113,29 @@ With Blackmagic Debug Probe using the SWD interface:
   `break <full/source/code/file/path>:<linenumber>`
 - step through / step in with GDB commands (next/n, step in/si, ..)
 
-## Native Simulator
+## Emulator
 
 Note: the Zephyr native simulator only works on Linux.
 
-The native simulator uses the flash simulator to provide storage.
-It creates a 100 MB file named `flash.bin`, which contains a FAT file system.
-This replaces the SD card.
+To build the emulator,
+build the ZEReader app for the `native_sim` board:
 
-To build for the native simulator, build the app for the `native_sim/native/64` board.
-The run it from the build directory: `./build/zephyr/zephyr.exe`.
+```
+west build -b native_sim/native/64 app
+```
 
-The flash backing file can either be created manually beforehand,
-or on the first run of the emulator.
+To run the emluator, execute this command:
+
+```
+./build/zephyr/zephyr.exe
+```
+
+The native simulator uses emulated flash to provide storage,
+which replaces the SD card from the actual board.
+This emulated storage is backed by a 100 MB file named `flash.bin`,
+located in the directory where the emulator is run.
+If this file does not exist,
+the emulator creates it.
 To put data onto the simulated SD card,
 mount the file on the host and copy the data into it:
 
@@ -140,8 +150,18 @@ FUSE access to the simulated storage can be enabled:
 
 ```
 west build -b native_sim/native/64 app -- -DCONFIG_FUSE_FS_ACCESS=y
+```
+
+When the emulator is running,
+it mounts the simulated SD card on the directory `flash/SD:`,
+so the book can be copied there:
+
+```
 cp -r my-book flash/SD\:/
 ```
+
+In any case,
+the emulator needs to be restarted after new books are added to the simulated SD card.
 
 ## Current state
 This is still a work-in-process.

--- a/README.md
+++ b/README.md
@@ -113,6 +113,36 @@ With Blackmagic Debug Probe using the SWD interface:
   `break <full/source/code/file/path>:<linenumber>`
 - step through / step in with GDB commands (next/n, step in/si, ..)
 
+## Native Simulator
+
+Note: the Zephyr native simulator only works on Linux.
+
+The native simulator uses the flash simulator to provide storage.
+It creates a 100 MB file named `flash.bin`, which contains a FAT file system.
+This replaces the SD card.
+
+To build for the native simulator, build the app for the `native_sim/native/64` board.
+The run it from the build directory: `./build/zephyr/zephyr.exe`.
+
+The flash backing file can either be created manually beforehand,
+or on the first run of the emulator.
+To put data onto the simulated SD card,
+mount the file on the host and copy the data into it:
+
+```
+sudo mount -o loop flash.bin /mnt
+sudo cp -r my-book /mnt
+sudo umount /mnt
+```
+
+Alternatively, if the FUSE development headers are installed,
+FUSE access to the simulated storage can be enabled:
+
+```
+west build -b native_sim/native/64 app -- -DCONFIG_FUSE_FS_ACCESS=y
+cp -r my-book flash/SD\:/
+```
+
 ## Current state
 This is still a work-in-process.
 The firmware shows a proof-of-concept that reading EPUBs as they are is possible with the available resources of a cheap microcontroller unit like the RP2040/RP2350.

--- a/app/boards/native_sim_64.overlay
+++ b/app/boards/native_sim_64.overlay
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: 2025 Florian Limberger <flo@purplekraken.com>
+//
+// SPDX-License-Identifier: MPL-2.0
+
+#include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/lvgl/lvgl.h>
+
+&flashcontroller0 {
+	reg = <0x00000000 DT_SIZE_K(1024 * 100)>;
+};
+
+&flash0 {
+	reg = <0x00000000 DT_SIZE_K(1024 * 100)>;
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		flashdisk_partition: partition@0 {
+			reg = <0x00000000 DT_SIZE_K(1024 * 100)>;
+		};
+	};
+};
+
+&sdl_dc {
+	compatible = "zephyr,sdl-dc";
+	height = <480>;
+	width = <800>;
+};
+
+/ {
+	keys: keys {
+		compatible = "gpio-keys";
+		button1: button1 {
+			gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
+			zephyr,code = <INPUT_KEY_1>;
+		};
+
+		button2: button2 {
+			gpios = <&gpio0 3 GPIO_ACTIVE_LOW>;
+			zephyr,code = <INPUT_KEY_2>;
+		};
+
+		button3: button3 {
+			gpios = <&gpio0 4 GPIO_ACTIVE_LOW>;
+			zephyr,code = <INPUT_KEY_3>;
+		};
+
+		button4: button4 {
+			gpios = <&gpio0 5 GPIO_ACTIVE_LOW>;
+			zephyr,code = <INPUT_KEY_4>;
+		};
+	};
+
+	lvgl_button_input: lvgl_button_input {
+		compatible = "zephyr,lvgl-button-input";
+		input = <&keys>;
+		input-codes = <INPUT_KEY_1 INPUT_KEY_2 INPUT_KEY_3 INPUT_KEY_4>;
+		coordinates = <10 470>, <360 470>, <450 470>, <770 470>;
+	};
+
+	sdcard_emulation: sdcard_emulation {
+		compatible = "zephyr,flash-disk";
+		partition = <&flashdisk_partition>;
+		disk-name = "SD"; /* this is the same name as the SD card reader */
+		cache-size = <4096>;
+	};
+};

--- a/app/boards/native_sim_native_64.conf
+++ b/app/boards/native_sim_native_64.conf
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: 2025 Florian Limberger <flo@purplekraken.com>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+# Native_sim uses simulated flash instead of an SD card
+CONFIG_FLASH=y
+
+# This needs the FUSE development headers installed:
+#CONFIG_FUSE_FS_ACCESS=y

--- a/app/prj.conf
+++ b/app/prj.conf
@@ -9,7 +9,6 @@ CONFIG_ZEREADER_LOG_LEVEL_DBG=y
 
 # General config
 CONFIG_GPIO=y
-CONFIG_SPI=y
 
 CONFIG_SERIAL=y
 # CONFIG_PRINTK=y
@@ -23,7 +22,6 @@ CONFIG_UART_CONSOLE=y
 # DISK ACCESS
 ####################################
 CONFIG_DISK_ACCESS=y
-CONFIG_DISK_DRIVER_SDMMC=y
 
 CONFIG_FILE_SYSTEM=y
 CONFIG_FAT_FILESYSTEM_ELM=y
@@ -43,11 +41,6 @@ CONFIG_FS_FATFS_MAX_LFN=255
 # CONFIG_FS_FATFS_NUM_FILES=4
 # Unicode codepages
 # CONFIG_FS_FATFS_CODEPAGE=
-
-# For Debug Output
-CONFIG_SD_LOG_LEVEL_DBG=n
-CONFIG_SDHC_LOG_LEVEL_DBG=n
-CONFIG_SDMMC_LOG_LEVEL_DBG=n
 
 # Config memory
 # Make sure the configured stack size matches the size of

--- a/app/src/epub/epub.c
+++ b/app/src/epub/epub.c
@@ -103,7 +103,7 @@ int epub_write_current_book_state()
     size_t to_write;
     char state_string[500];
 
-    sprintf(state_string, "%s\n%d\n%d\n", current_book->state.title, current_book->state.chapter, current_book->state.file_offset);
+    sprintf(state_string, "%s\n%zu\n%zu\n", current_book->state.title, current_book->state.chapter, current_book->state.file_offset);
     to_write = strlen(state_string);
 
     int ret = sd_write_chunk(STATE_FILE, state_string, &to_write);

--- a/app/src/epub/epub.c
+++ b/app/src/epub/epub.c
@@ -93,6 +93,11 @@ book_list_t *epub_get_book_list()
 
 int epub_write_current_book_state()
 {
+    if (!current_book) {
+        LOG_DBG("No current book");
+        /* There is nothing to do, which is always successful */
+        return 0;
+    }
     LOG_DBG("Writing the book's state");
 
     size_t to_write;
@@ -109,7 +114,7 @@ int epub_write_current_book_state()
     return ret;
 }
 
-void epub_get_current_book_state()
+current_book_t *epub_get_current_book_state()
 {
     size_t size = 500;
     char buf[size];
@@ -119,7 +124,10 @@ void epub_get_current_book_state()
     size_t chapter = 0;
     size_t ofs = 0;
 
-    sd_read_chunk(STATE_FILE, &offset, buf, &size);
+    int err = sd_read_chunk(STATE_FILE, &offset, buf, &size);
+    if (err != 0) {
+        return NULL;
+    }
     LOG_DBG("Current state:\n %s", buf);
 
     char *token = strtok(buf, "\n");
@@ -143,11 +151,14 @@ void epub_get_current_book_state()
         LOG_DBG("Offset: %d", ofs);
     }
 
-    free(current_book);
-    current_book = (current_book_t *)malloc(sizeof(current_book_t));
-    current_book->state.title = strdup(title);
-    current_book->state.chapter = chapter;
-    current_book->state.file_offset = ofs;
+    current_book_t *current_book = malloc(sizeof(current_book_t));
+    if (current_book) {
+        current_book->state.title = strdup(title);
+        current_book->state.chapter = chapter;
+        current_book->state.file_offset = ofs;
+    }
+
+    return current_book;
 }
 
 chapter_entry_t *epub_add_chapter_entry()
@@ -611,15 +622,15 @@ int epub_fetch_next_page_chunk()
 
 char *epub_get_next_page()
 {
-
-    if (epub_fetch_next_page_chunk() == 0)
-    {
-        memset(current_book->pretty_page, 0, sizeof(current_book->pretty_page));
-        epub_prettify_page();
-        LOG_DBG("Pretty page: %s", current_book->pretty_page);
-        return current_book->pretty_page;
+    if (current_book) {
+        if (epub_fetch_next_page_chunk() == 0) {
+            memset(current_book->pretty_page, 0, sizeof(current_book->pretty_page));
+            epub_prettify_page();
+            LOG_DBG("Pretty page: %s", current_book->pretty_page);
+            return current_book->pretty_page;
+        }
     }
-    LOG_DBG("Can't get page");
+    LOG_DBG("No current book");
     return "";
 }
 
@@ -662,15 +673,15 @@ int epub_fetch_prev_page_chunk()
 
 char *epub_get_prev_page()
 {
-
-    if (epub_fetch_prev_page_chunk() == 0)
-    {
-        memset(current_book->pretty_page, 0, sizeof(current_book->pretty_page));
-        epub_prettify_page();
-        LOG_DBG("Pretty page: %s", current_book->pretty_page);
-        return current_book->pretty_page;
+    if (current_book) {
+        if (epub_fetch_prev_page_chunk() == 0) {
+            memset(current_book->pretty_page, 0, sizeof(current_book->pretty_page));
+            epub_prettify_page();
+            LOG_DBG("Pretty page: %s", current_book->pretty_page);
+            return current_book->pretty_page;
+        }
     }
-    LOG_DBG("Can't get page");
+    LOG_DBG("No current book");
     return "";
 }
 
@@ -697,7 +708,15 @@ int epub_restore_book()
 {
     book_entry_t *book = NULL;
 
-    epub_get_current_book_state();
+    if (current_book) {
+        free(current_book);
+    }
+    current_book = epub_get_current_book_state();
+    if (!current_book) {
+        LOG_INF("No current book state found.");
+        return -ENOENT;
+    }
+
     LOG_DBG("Restore title %s", current_book->state.title);
     book = epub_get_book_entry_for_title(current_book->state.title);
 

--- a/app/src/main.c
+++ b/app/src/main.c
@@ -47,11 +47,13 @@ int main(void)
 	display_blanking_off(display_dev);
 
 	epub_initialize();
-	epub_restore_book();
+	int err = epub_restore_book();
 
 	zereader_clean_page();
 
-	zereader_print_current_page();
+	if (err == 0) {
+		zereader_print_current_page();
+	}
 
 	lv_timer_handler();
 

--- a/app/src/ui/ui.c
+++ b/app/src/ui/ui.c
@@ -6,6 +6,9 @@
 
 #include <epub/epub.h>
 
+#include <stdio.h>
+#include <string.h>
+
 #include <ui/ui.h>
 #include <ui/fonts/notoserif_14.h>
 #include <ui/logo/zereaderlogomarx.h>

--- a/app/src/ui/ui.c
+++ b/app/src/ui/ui.c
@@ -10,7 +10,18 @@
 #include <string.h>
 
 #include <ui/ui.h>
+
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wbidi-chars"
+#endif /* __GNUC__ */
+
 #include <ui/fonts/notoserif_14.h>
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif /* __GNUC__ */
+
 #include <ui/logo/zereaderlogomarx.h>
 
 #include <zephyr/logging/log.h>

--- a/app/src/ui/ui.c
+++ b/app/src/ui/ui.c
@@ -80,7 +80,7 @@ void zereader_show_bookmenu(context_t *context)
 	while (books != NULL)
 	{
 		LOG_DBG("NR: %d - %s - %s - %s - %s", books->book->number, books->book->title, books->book->author, books->book->root_dir, books->book->entry_point);
-		snprintf(book_entry, 49, "%d - %s - %s", books->book->number, books->book->author, books->book->title);
+		snprintf(book_entry, 49, "%zu - %s - %s", books->book->number, books->book->author, books->book->title);
 		LOG_DBG("book_entry: %s", book_entry);
 		strcat(book_entry, "\n");
 		strcat(book_list, book_entry);

--- a/doc/docs/emulator.rst
+++ b/doc/docs/emulator.rst
@@ -1,0 +1,55 @@
+.. SPDX-FileCopyrightText: 2025 Florian Limberger
+..
+.. SPDX-License-Identifier: MPL-2.0
+
+Emulator
+========
+
+The ZEReader firmware can run in an emulator on Linux,
+based on the ``native_sim`` board.
+It enables developers to run the firmware without needing actual hardware,
+which comes in handy for testing changes not related to the hardware,
+e.g. to the UI or EPUB handling code.
+
+Building and Running
+--------------------
+
+To build the emulator,
+simply build the ``app`` for the ``native_sim`` board::
+
+    west build -b native_sim/native/64 app
+
+To simplify access to the emulated flash storage,
+the FUSE development headers need to be present on the build host.
+On Ubuntu, they are provided by the ``libfuse-dev`` package,
+on AlmaLinux 9 by the ``fuse-devel`` package.
+The app needs to be configured to use FUSE to access the emulated storage::
+
+    west build -b native_sim/native/64 app -- -DCONFIG_FUSE_FS_ACCESS=y
+
+The emulator is started by running the ``zephyr.exe`` binary file from the ``native_sim`` build
+directory::
+
+    ./build/zephyr/zephyr.exe
+
+Storage Emulation
+-----------------
+
+The emulated storage uses a file named ``flash.bin``.
+If it is not already present when the emulator is started,
+the emulator creates it.
+
+To put books onto the flash,
+it needs to be mounted as a loopback device::
+
+    sudo mount -o loop flash.bin /mnt
+    sudo cp -r my-book /mnt
+    sudo umount /mnt
+
+If the emulator is built with FUSE support,
+the books can just be copied to the ``flash/SD:`` directory when the emulator is running::
+
+    cp -r my-book flash/SD\:
+
+The emulator creates a ``flash`` directory in its working directory,
+which can be safely removed after the emulator is stopped.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -22,6 +22,7 @@ this hackable and customizable platform.
    docs/about
    docs/getting-started
    docs/debugging
+   docs/emulator
    docs/contributing
    
 

--- a/include/epub/epub.h
+++ b/include/epub/epub.h
@@ -274,8 +274,10 @@ int epub_write_current_book_state();
 
 /**
  * @brief Restore the book state from a state file on the inserted SD card.
+ *
+ * @returns A freshly allocated current book
  */
-void epub_get_current_book_state();
+current_book_t *epub_get_current_book_state();
 
 /** @} */
 #endif


### PR DESCRIPTION
Add support for the `native_sim` board. This will simplify testing changes to the UI and epub logic which don't relate to hardware.