### PR TITLE
fix: ADC configuration

### DIFF
--- a/boards/zereader/common/zereader_pi-pico-common.dtsi
+++ b/boards/zereader/common/zereader_pi-pico-common.dtsi
@@ -4,74 +4,74 @@
 
 /* The Pico and Pico 2 are pin compatible. */
 &pinctrl {
-	uart0_default: uart0_default {
-		group1 {
-			pinmux = <UART0_TX_P0>;
-		};
+  uart0_default: uart0_default {
+    group1 {
+      pinmux = <UART0_TX_P0>;
+    };
 
-		group2 {
-			pinmux = <UART0_RX_P1>;
-			input-enable;
-		};
-	};
+    group2 {
+      pinmux = <UART0_RX_P1>;
+      input-enable;
+    };
+  };
 
-	i2c0_default: i2c0_default {
-		group1 {
-			pinmux = <I2C0_SDA_P4>, <I2C0_SCL_P5>;
-			input-enable;
-			input-schmitt-enable;
-		};
-	};
+  i2c0_default: i2c0_default {
+    group1 {
+      pinmux = <I2C0_SDA_P4>, <I2C0_SCL_P5>;
+      input-enable;
+      input-schmitt-enable;
+    };
+  };
 
-	i2c1_default: i2c1_default {
-		group1 {
-			pinmux = <I2C1_SDA_P6>, <I2C1_SCL_P7>;
-			input-enable;
-			input-schmitt-enable;
-		};
-	};
+  i2c1_default: i2c1_default {
+    group1 {
+      pinmux = <I2C1_SDA_P6>, <I2C1_SCL_P7>;
+      input-enable;
+      input-schmitt-enable;
+    };
+  };
 
-	spi0_default: spi0_default {
-		group1 {
-			pinmux = <SPI0_CSN_P17>, <SPI0_SCK_P18>, <SPI0_TX_P19>;
-		};
+  spi0_default: spi0_default {
+    group1 {
+      pinmux = <SPI0_CSN_P17>, <SPI0_SCK_P18>, <SPI0_TX_P19>;
+    };
 
-		group2 {
-			pinmux = <SPI0_RX_P16>;
-			input-enable;
-		};
-	};
+    group2 {
+      pinmux = <SPI0_RX_P16>;
+      input-enable;
+    };
+  };
 
-	spi1_zereader_v1: spi1_zereader_v1 {
-		group1 {
-			pinmux = <SPI1_CSN_P13>, <SPI1_SCK_P10>, <SPI1_TX_P11>;
-		};
-		group2 {
-			pinmux = <SPI1_RX_P12>;
-			input-enable;
-		};
-	};
+  spi1_zereader_v1: spi1_zereader_v1 {
+    group1 {
+      pinmux = <SPI1_CSN_P13>, <SPI1_SCK_P10>, <SPI1_TX_P11>;
+    };
+    group2 {
+      pinmux = <SPI1_RX_P12>;
+      input-enable;
+    };
+  };
 
-	spi1_zereader_v2: spi1_zereader_v2 {
-		group1 {
-			pinmux = <SPI1_CSN_P9>, <SPI1_SCK_P10>, <SPI1_TX_P11>;
-		};
-		group2 {
-			pinmux = <SPI1_RX_P8>;
-			input-enable;
-		};
-	};
+  spi1_zereader_v2: spi1_zereader_v2 {
+    group1 {
+      pinmux = <SPI1_CSN_P9>, <SPI1_SCK_P10>, <SPI1_TX_P11>;
+    };
+    group2 {
+      pinmux = <SPI1_RX_P8>;
+      input-enable;
+    };
+  };
 
-	pwm_ch4b_default: pwm_ch4b_default {
-		group1 {
-			pinmux = <PWM_4B_P25>;
-		};
-	};
+  pwm_ch4b_default: pwm_ch4b_default {
+    group1 {
+      pinmux = <PWM_4B_P25>;
+    };
+  };
 
-	adc_default: adc_default {
-		group1 {
-			pinmux = <ADC_CH0_P26>, <ADC_CH1_P27>, <ADC_CH2_P28>, <ADC_CH3_P29>;
-			input-enable;
-		};
-	};
+  adc_default: adc_default {
+    group1 {
+      pinmux = <ADC_CH0_P26>, <ADC_CH1_P27>, <ADC_CH2_P28>, <ADC_CH3_P29>;
+      bias-disable;
+    };
+  };
 };

--- a/boards/zereader/zereader_rev2/zereader_rev2.dtsi
+++ b/boards/zereader/zereader_rev2/zereader_rev2.dtsi
@@ -13,145 +13,104 @@
 
 // TODO
 // Not yet configured:
-// SD_DAT1 		-> GP6
-// SD_DAT2 		-> GP7
-// SD_DETECT 	-> GP5
+// SD_DAT1     -> GP6
+// SD_DAT2     -> GP7
+// SD_DETECT   -> GP5
 / {
-	chosen {
-		zephyr,sram = &sram0;
-		zephyr,flash = &flash0;
-		zephyr,flash-controller = &qmi;
-		zephyr,console = &uart0;
-		zephyr,shell-uart = &uart0;
-		zephyr,display = &uc8179_waveshare_epaper_gdew075t7;
-	};
+  chosen {
+    zephyr,sram = &sram0;
+    zephyr,flash = &flash0;
+    zephyr,flash-controller = &qmi;
+    zephyr,console = &uart0;
+    zephyr,shell-uart = &uart0;
+    zephyr,display = &uc8179_waveshare_epaper_gdew075t7;
+  };
 
-	aliases {
-		watchdog0 = &wdt0;
-		devicestatecontrol = &powercontrol;
-	};
+  aliases {
+    watchdog0 = &wdt0;
+    devicestatecontrol = &powercontrol;
+  };
 
-	zephyr,user {
-		io-channels = <&adc 3>;
-	};
+  zephyr,user {
+    io-channels = <&adc 3>;
+  };
 
-	mipi_dbi_waveshare_epaper_gdew075t7 {
-		compatible = "zephyr,mipi-dbi-spi";
-		spi-dev = <&spi0>; //spi@0 -> GPIO 16-19
-		dc-gpios = <&gpio0 20 GPIO_ACTIVE_HIGH>;
-		reset-gpios = <&gpio0 21 GPIO_ACTIVE_LOW>;
-		write-only;
-		#address-cells = <1>;
-		#size-cells = <0>;
+  mipi_dbi_waveshare_epaper_gdew075t7 {
+    compatible = "zephyr,mipi-dbi-spi";
+    spi-dev = <&spi0>; //spi@0 -> GPIO 16-19
+    dc-gpios = <&gpio0 20 GPIO_ACTIVE_HIGH>;
+    reset-gpios = <&gpio0 21 GPIO_ACTIVE_LOW>;
+    write-only;
+    #address-cells = <1>;
+    #size-cells = <0>;
 
-		uc8179_waveshare_epaper_gdew075t7: uc8179@0 {
-			compatible = "gooddisplay,gdew075t7", "ultrachip,uc8179";
-			mipi-max-frequency = <4000000>;
-			reg = <0>;
-			width = <800>;
-			height = <480>;
-			busy-gpios = <&gpio0 22 GPIO_ACTIVE_LOW>;
+    uc8179_waveshare_epaper_gdew075t7: uc8179@0 {
+      compatible = "gooddisplay,gdew075t7", "ultrachip,uc8179";
+      mipi-max-frequency = <4000000>;
+      reg = <0>;
+      width = <800>;
+      height = <480>;
+      busy-gpios = <&gpio0 22 GPIO_ACTIVE_LOW>;
 
-			softstart = [ 17 17 28 17  ];
+      softstart = [ 17 17 28 17  ];
 
-			full {
-				pwr = [ 07 07 3f 3f 09  ];
-				cdi = <0x07>;
-				tcon = <0x60>;
-				pll = <0x30>;
-			};
+      full {
+        pwr = [ 07 07 3f 3f 09  ];
+        cdi = <0x07>;
+        tcon = <0x60>;
+        pll = <0x30>;
+      };
 
-			partial {
-				pwr = [ 07 07 3f 3f 09  ];
-				cdi = <0x07>;
-				pll = <0x3c>;
-				vdcs = <0x08>;
+      partial {
+        pwr = [ 07 07 3f 3f 09  ];
+        cdi = <0x07>;
+        pll = <0x3c>;
+        vdcs = <0x08>;
 
-				        lutc = [
-					00 01 0E 00 00 01
-					00 00 00 00 00 00
-					00 00 00 00 00 00
-					00 00 00 00 00 00
-					00 00 00 00 00 00
-					00 00 00 00 00 00
-					00 00 00 00 00 00
-					00 00
-				];
+        lutc = [ 00 01 0E 00 00 01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ];
 
-				lutww = [
-					00 01 0E 00 00 01
-					00 00 00 00 00 00
-					00 00 00 00 00 00
-					00 00 00 00 00 00
-					00 00 00 00 00 00
-					00 00 00 00 00 00
-					00 00 00 00 00 00
-				];
+        lutww = [ 00 01 0E 00 00 01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ];
 
-				lutkw = [
-					20 01 0E 00 00 01
-					00 00 00 00 00 00
-					00 00 00 00 00 00
-					00 00 00 00 00 00
-					00 00 00 00 00 00
-					00 00 00 00 00 00
-					00 00 00 00 00 00
-				];
+        lutkw = [ 20 01 0E 00 00 01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ];
 
-				lutwk = [
-					10 01 0E 00 00 01
-					00 00 00 00 00 00
-					00 00 00 00 00 00
-					00 00 00 00 00 00
-					00 00 00 00 00 00
-					00 00 00 00 00 00
-					00 00 00 00 00 00
-				];
+        lutwk = [ 10 01 0E 00 00 01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ];
 
-				lutkk = [
-					00 01 0E 00 00 01
-					00 00 00 00 00 00
-					00 00 00 00 00 00
-					00 00 00 00 00 00
-					00 00 00 00 00 00
-					00 00 00 00 00 00
-					00 00 00 00 00 00
-				];
-			};
-		};
-	};
+        lutkk = [ 00 01 0E 00 00 01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ];
+      };
+    };
+  };
 
-	keys: keys {
-		compatible = "gpio-keys";
-		button1: button1 {
-			gpios = <&gpio0 15 GPIO_ACTIVE_LOW>;
-			zephyr,code = <INPUT_KEY_1>;
-		};
+  keys: keys {
+    compatible = "gpio-keys";
+    button1: button1 {
+      gpios = <&gpio0 15 GPIO_ACTIVE_LOW>;
+      zephyr,code = <INPUT_KEY_1>;
+    };
 
-		button2: button2 {
-			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
-			zephyr,code = <INPUT_KEY_2>;
-		};
+    button2: button2 {
+      gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
+      zephyr,code = <INPUT_KEY_2>;
+    };
 
-		button3: button3 {
-			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
-			zephyr,code = <INPUT_KEY_3>;
-		};
+    button3: button3 {
+      gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
+      zephyr,code = <INPUT_KEY_3>;
+    };
 
-		button4: button4 {
-			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
-			zephyr,code = <INPUT_KEY_4>;
-		};
-	};
+    button4: button4 {
+      gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
+      zephyr,code = <INPUT_KEY_4>;
+    };
+  };
 
-	lvgl_button_input: lvgl_button_input {
-		compatible = "zephyr,lvgl-button-input";
-		input = <&keys>;
-		input-codes = <INPUT_KEY_1 INPUT_KEY_2 INPUT_KEY_3 INPUT_KEY_4>;
-		coordinates = <10 470>, <360 470>, <450 470>, <770 470>;
-	};
+  lvgl_button_input: lvgl_button_input {
+    compatible = "zephyr,lvgl-button-input";
+    input = <&keys>;
+    input-codes = <INPUT_KEY_1 INPUT_KEY_2 INPUT_KEY_3 INPUT_KEY_4>;
+    coordinates = <10 470>, <360 470>, <450 470>, <770 470>;
+  };
 
-	powerpin: powerpin {
+  powerpin: powerpin {
     compatible = "gpio-leds";
     powercontrol: powercontrol {
       gpios = <&gpio0 28 GPIO_ACTIVE_HIGH>;
@@ -177,93 +136,94 @@
 };
 
 &flash0 {
-	reg = <0x10000000 DT_SIZE_M(4)>;
+  reg = <0x10000000 DT_SIZE_M(4)>;
 };
 
 &uart0 {
-	current-speed = <115200>;
-	status = "okay";
-	pinctrl-0 = <&uart0_default>;
-	pinctrl-names = "default";
+  current-speed = <115200>;
+  status = "okay";
+  pinctrl-0 = <&uart0_default>;
+  pinctrl-names = "default";
 };
 
 gpio0_lo: &gpio0 {
-	status = "okay";
+  status = "okay";
 };
 
 &spi0 {
-	clock-frequency = <DT_FREQ_M(8)>;
-	pinctrl-0 = <&spi0_default>;
-	pinctrl-names = "default";
-	status = "okay";
+  clock-frequency = <DT_FREQ_M(8)>;
+  pinctrl-0 = <&spi0_default>;
+  pinctrl-names = "default";
+  status = "okay";
 };
 
 &spi1 {
-	clock-frequency = <DT_FREQ_M(8)>;
-	pinctrl-0 = <&spi1_zereader_v2>;
-	pinctrl-names = "default";
-	status = "okay";
+  clock-frequency = <DT_FREQ_M(8)>;
+  pinctrl-0 = <&spi1_zereader_v2>;
+  pinctrl-names = "default";
+  status = "okay";
 
-	cs-gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
-	sdhc0: sdhc@0 {
-		compatible = "zephyr,sdhc-spi-slot";
-		reg = <0>;
-		status = "okay";
-		mmc {
-			compatible = "zephyr,sdmmc-disk";
-			disk-name = "SD";
-			status = "okay";
-		};
-		spi-max-frequency = <10000000>;
-	};
+  cs-gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
+  sdhc0: sdhc@0 {
+    compatible = "zephyr,sdhc-spi-slot";
+    reg = <0>;
+    status = "okay";
+    mmc {
+      compatible = "zephyr,sdmmc-disk";
+      disk-name = "SD";
+      status = "okay";
+    };
+    spi-max-frequency = <10000000>;
+  };
 };
 
 &i2c0 {
-	clock-frequency = <I2C_BITRATE_STANDARD>;
-	pinctrl-0 = <&i2c0_default>;
-	pinctrl-names = "default";
-	status = "disabled";
+  clock-frequency = <I2C_BITRATE_STANDARD>;
+  pinctrl-0 = <&i2c0_default>;
+  pinctrl-names = "default";
+  status = "disabled";
 };
 
 &i2c1 {
-	clock-frequency = <I2C_BITRATE_STANDARD>;
-	pinctrl-0 = <&i2c1_default>;
-	pinctrl-names = "default";
-	status = "disabled";
+  clock-frequency = <I2C_BITRATE_STANDARD>;
+  pinctrl-0 = <&i2c1_default>;
+  pinctrl-names = "default";
+  status = "disabled";
 };
 
 &adc {
-	#address-cells = <1>;
-	#size-cells = <0>;
-	pinctrl-0 = <&adc_default>;
-	pinctrl-names = "default";
-	status = "okay";
+  #address-cells = <1>;
+  #size-cells = <0>;
+  pinctrl-0 = <&adc_default>;
+  pinctrl-names = "default";
+  status = "okay";
 
-	channel@3{
-		reg = <3>;
-		zephyr,gain = "ADC_GAIN_1";
-		zephyr,reference = "ADC_REF_INTERNAL";
-		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
-		zephyr,resolution = <12>;
-	};
+  channel@3 {
+    reg = <3>;
+    zephyr,gain = "ADC_GAIN_1";
+    zephyr,reference = "ADC_REF_VDD_1";
+    zephyr,vref-mv = <3300>;
+    zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+    zephyr,resolution = <12>;
+  };
 };
 
 &pwm {
-	pinctrl-0 = <&pwm_ch4b_default>;
-	pinctrl-names = "default";
-	divider-int-0 = <255>;
+  pinctrl-0 = <&pwm_ch4b_default>;
+  pinctrl-names = "default";
+  divider-int-0 = <255>;
 };
 
 &timer0 {
-	status = "okay";
+  status = "okay";
 };
 
 &wdt0 {
-	status = "okay";
+  status = "okay";
 };
 
 zephyr_udc0: &usbd {
-	status = "okay";
+  status = "okay";
 };
 
 pico_serial: &uart0 {};

--- a/lib/ui/widgets/status_bar.c
+++ b/lib/ui/widgets/status_bar.c
@@ -14,7 +14,7 @@ LOG_MODULE_REGISTER(status_bar, CONFIG_ZEREADER_LOG_LEVEL);
 #define BATTERY_UPDATE_INTERVAL_MS 120000 // Update every 120 seconds
 #define BAT_MIN_MV 3300                   // 0% charge (3.3V)
 #define BAT_MAX_MV 4200                   // 100% charge (4.2V)
-#define BAT_CHARGER_MV 4900               // Threshold to detect charger (approx 5V)
+#define BAT_CHARGER_MV 4500               // Threshold to detect charger (approx 5V)
 
 extern const struct adc_dt_spec adc_chan3_vsys;
 static lv_obj_t *bat_label;
@@ -69,10 +69,12 @@ static void update_battery_cb(lv_timer_t *timer)
 
   if (adc_raw_to_millivolts_dt(&adc_chan3_vsys, &val_mv) == 0)
   {
+    LOG_DBG("Battery voltage raw: %d", val_mv);
     val_mv = (val_mv * 3);
     val_mv = val_mv - 50;
     val_mv /= 10;
     val_mv *= 10;
+    LOG_DBG("Battery voltage: %d", val_mv);
   }
 
   if (val_mv >= BAT_CHARGER_MV)


### PR DESCRIPTION
The ADC's configuration was broken and with updating the Zephyr version,
the issue came visible with incorrect values read.
This configures it correctly with the bias-disable option instead of
input-enable and set a specific reference value.